### PR TITLE
缩短Cloudflare TTL时间

### DIFF
--- a/ue-ddns.sh
+++ b/ue-ddns.sh
@@ -623,7 +623,7 @@ getIP_cloudflare() {
 
 ddns_update_cloudflare() {
     postMethod="PUT"
-    postData="{\"type\":\"""$ddns_IPVType""\",\"name\":\"""$ddns_record_domain""\",\"content\":\"""$ddns_newIP""\",\"ttl\":1,\"proxiable\":true,\"proxied\":""$cloudflare_cdn""}"
+    postData="{\"type\":\"""$ddns_IPVType""\",\"name\":\"""$ddns_record_domain""\",\"content\":\"""$ddns_newIP""\",\"ttl\":60,\"proxiable\":true,\"proxied\":""$cloudflare_cdn""}"
     test_ddns_result=$(fetch_cloudflare "$cloudflare_zoneid"/dns_records/"$cloudflare_record_id")
     postData=""
     postMethod=""
@@ -638,7 +638,7 @@ ddns_update_cloudflare() {
 #func-ddns_update_cloudflare
 
 addsub_cloudflare() {
-    postData="{\"type\":\"${ddns_IPVType}\",\"name\":\"""$ddns_newsubdomain"".""$ddns_main_domain""\",\"content\":\"""$new_initIP""\",\"ttl\":1,\"proxied\":false}"
+    postData="{\"type\":\"${ddns_IPVType}\",\"name\":\"""$ddns_newsubdomain"".""$ddns_main_domain""\",\"content\":\"""$new_initIP""\",\"ttl\":60,\"proxied\":false}"
     cloudflare_record_id=$(fetch_cloudflare "$cloudflare_zoneid"/dns_records | grep -Eo '"id":"[0-9a-z]{32}' | grep -Eo "[0-9a-z]{32}")
     postData=""
     if [ -z "$cloudflare_record_id" ]; then


### PR DESCRIPTION
目前脚本在更新Cloudflare DNS记录时将TTL设置为1，即自动，通过[论坛](https://community.cloudflare.com/t/details-of-auto-ttl/369031/3)和`dig`得知自动其实就是300秒。Cloudflare免费版最低支持60秒的TTL，默认更短可以使DDNS记录更快更新。

参考：https://developers.cloudflare.com/api/operations/dns-records-for-a-zone-update-dns-record